### PR TITLE
Fixed incorrect class name in example html

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following is the bare minimum HTML needed in your document:
 	  <h2 id="glossary-title">Glossary</h2>
 	  <label for="glossary-search">Filter glossary terms</label>
 	  <input id="glossary-search" class="js-glossary-search" type="search" placeholder="e.g. Committee">
-	  <ul class="js-glossary-search"></ul>
+	  <ul class="js-glossary-list"></ul>
 	</div>
 ```
 


### PR DESCRIPTION
`defaultSelectors` in `glossary.js` looks for `listClass: '.js-glossary-list',`, but the example HTML in the repo is missing this classname. Based on `tests/glossary.js`, it looks like the example just contains one typo, fixed in this PR.
