### PR TITLE
Closing panel will change focus to clicked term

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -145,6 +145,7 @@ Glossary.prototype.handleTermTouch = function(e) {
   if (e.which === KEYCODE_ENTER || e.type === 'click') {
     if (selectorMatches(e.target, '[data-term]')) {
       this.show();
+      this.$selectedTerm = $(e.target);
       this.findTerm(e.target.getAttribute('data-term'));
     }
   }
@@ -187,6 +188,7 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
+  this.$selectedTerm.focus();
   this.isOpen = false;
   removeTabindex(this.body);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -144,9 +144,12 @@ Glossary.prototype.linkTerms = function() {
 Glossary.prototype.handleTermTouch = function(e) {
   if (e.which === KEYCODE_ENTER || e.type === 'click') {
     if (selectorMatches(e.target, '[data-term]')) {
-      this.show();
-      this.$selectedTerm = $(e.target);
+      this.show(e);
+      this.selectedTerm = e.target;
       this.findTerm(e.target.getAttribute('data-term'));
+    }
+    else {
+      this.selectedTerm = this.toggleBtn;
     }
   }
 };
@@ -188,7 +191,7 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
-  this.$selectedTerm.focus();
+  this.selectedTerm.focus();
   this.isOpen = false;
   removeTabindex(this.body);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -187,7 +187,6 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
-  this.toggleBtn.focus();
   this.isOpen = false;
   removeTabindex(this.body);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -79,6 +79,7 @@ function Glossary(terms, selectors, classes) {
   this.closeBtn = document.querySelector(this.selectors.close);
   this.search = this.body.querySelector(this.selectors.searchClass);
   this.list = this.body.querySelector(this.selectors.listClass);
+  this.selectedTerm = this.toggleBtn;
 
   // Initialize state
   this.isOpen = false;


### PR DESCRIPTION
Closing the panel will now shift focus back to the clicked glossary term or toggled button (glossary nav link). This prevents the previous action when closing the glossary panel would shift focus and scroll towards the glossary button instead.
