### PR TITLE
Pin lower version for list.js and higher version for accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test": "mochify tests/glossary.js"
   },
   "dependencies": {
-    "aria-accordion": "0.1.0",
-    "list.js": "^1.2.0",
+    "aria-accordion": "0.1.2",
+    "list.js": "1.3.0",
     "underscore": "^1.8.3"
   },
   "main": "src/glossary.js",


### PR DESCRIPTION
This avoids a problem introduced in list.js v1.4.0 where it couldn’t find a module by just pinning to v1.3.0.

It also bumps up the version on the aria-accordion package. 