### PR TITLE
Remove lodash.template dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "aria-accordion": "1.0.0",
     "list.js": "1.3.0",
-    "lodash.template": "^4.4.0",
     "object-assign": "^4.1.1"
   },
   "main": "src/glossary.js",

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var List = require('list.js');
-var template = require('lodash.template');
 var objectAssign = require('object-assign');
 var Accordion = require('aria-accordion').Accordion;
 
@@ -33,14 +32,14 @@ function forEach(values, callback) {
   return [].forEach.call(values, callback);
 }
 
-var itemTemplate = template(
-  '<li class="{{ glossaryItemClass }}">' +
-    '<button class="data-glossary-term {{ termClass }}">{{ term }}' +
-    '</button>' +
-    '<div class="{{ definitionClass }}">{{ definition }}</div>' +
-  '</li>',
-  {interpolate: /\{\{(.+?)\}\}/g}
-);
+var itemTemplate = function(values) {
+  return '<li class="' + values.glossaryItemClass + '">' +
+      '<button class="data-glossary-term ' + values.termClass + '">' +
+        values.term +
+      '</button>' +
+      '<div class="' + values.definitionClass + '">' + values.definition + '</div>' +
+    '</li>'
+}
 
 var defaultSelectors = {
   glossaryID: '#glossary',


### PR DESCRIPTION
The template function was using eval() to get its job done, which causes problems when trying to implement a Content Security Policy (CSP). Since it was used in a simple place, I refactored to just use regular string concatenation.

Should close #34 