### PR TITLE
ensure example glossary is scrollable

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -16,6 +16,7 @@ body {
   right: 0;
   padding: .5rem;
   transition: right .2s;
+  overflow: scroll;
 }
 
 .glossary[aria-hidden=true] {


### PR DESCRIPTION
Vertical content was being cut off on short screens.