### PR TITLE
glossary component changes

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -38,7 +38,7 @@ li {
   list-style-type: none;
 }
 
-button {
+.testing {
   appearance: none;
   background-color: #0071bc;
   border: 1px solid #205493;

--- a/example/style.css
+++ b/example/style.css
@@ -38,7 +38,7 @@ li {
   list-style-type: none;
 }
 
-.testing {
+button {
   appearance: none;
   background-color: #0071bc;
   border: 1px solid #205493;

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -10,12 +10,16 @@ var KEYCODE_ESC = 27;
 // https://davidwalsh.name/element-matches-selector
 function selectorMatches(el, selector) {
   var p = Element.prototype;
-  var f = p.matches || p.webkitMatchesSelector || p.mozMatchesSelector || p.msMatchesSelector || function(s) {
-    return [].indexOf.call(document.querySelectorAll(s), this) !== -1;
-  };
+  var f =
+    p.matches ||
+    p.webkitMatchesSelector ||
+    p.mozMatchesSelector ||
+    p.msMatchesSelector ||
+    function(s) {
+      return [].indexOf.call(document.querySelectorAll(s), this) !== -1;
+    };
   return f.call(el, selector);
 }
-
 
 // get nearest parent element matching selector
 function closest(el, selector) {
@@ -33,27 +37,37 @@ function forEach(values, callback) {
 }
 
 var itemTemplate = function(values) {
-  return '<li class="' + values.glossaryItemClass + '">' +
-      '<button class="data-glossary-term ' + values.termClass + '">' +
-        values.term +
-      '</button>' +
-      '<div class="' + values.definitionClass + '">' + values.definition + '</div>' +
+  return (
+    '<li class="' +
+    values.glossaryItemClass +
+    '">' +
+    '<button class="data-glossary-term ' +
+    values.termClass +
+    '">' +
+    values.term +
+    '</button>' +
+    '<div class="' +
+    values.definitionClass +
+    '">' +
+    values.definition +
+    '</div>' +
     '</li>'
-}
+  );
+};
 
 var defaultSelectors = {
   glossaryID: '#glossary',
   toggle: '.js-glossary-toggle',
   close: '.js-glossary-close',
   listClass: '.js-glossary-list',
-  searchClass: '.js-glossary-search'
+  searchClass: '.js-glossary-search',
 };
 
 var defaultClasses = {
   definitionClass: 'glossary__definition',
   glossaryItemClass: 'glossary__item',
   highlightedTerm: 'term--highlight',
-  termClass: 'glossary__term'
+  termClass: 'glossary__term',
 };
 
 function removeTabindex(elm) {
@@ -105,7 +119,9 @@ function Glossary(terms, selectors, classes) {
   removeTabindex(this.body);
 
   // Initialize accordions
-  this.accordion = new Accordion(this.listElm, null, {contentPrefix: 'glossary'});
+  this.accordion = new Accordion(this.listElm, null, {
+    contentPrefix: 'glossary',
+  });
 
   // Bind listeners
   this.listeners = [];
@@ -113,7 +129,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
-  this.addEventListener(document,'click', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
 }
 
 Glossary.prototype.populate = function() {
@@ -123,7 +139,7 @@ Glossary.prototype.populate = function() {
       definition: term.definition,
       definitionClass: this.classes.definitionClass,
       glossaryItemClass: this.classes.glossaryItemClass,
-      termClass: this.classes.termClass
+      termClass: this.classes.termClass,
     };
     this.listElm.insertAdjacentHTML('beforeend', itemTemplate(opts));
   }, this);
@@ -140,7 +156,7 @@ Glossary.prototype.initList = function() {
     searchClass: searchClass,
   };
   this.list = new List(glossaryId, options);
-  this.list.sort('data-glossary-term', {order: 'asc'});
+  this.list.sort('data-glossary-term', { order: 'asc' });
 };
 
 /** Add links to terms in body */
@@ -149,7 +165,10 @@ Glossary.prototype.linkTerms = function() {
   forEach(terms, function(term) {
     term.setAttribute('title', 'Click to define');
     term.setAttribute('tabIndex', 0);
-    term.setAttribute('data-term', (term.getAttribute('data-term') || '').toLowerCase());
+    term.setAttribute(
+      'data-term',
+      (term.getAttribute('data-term') || '').toLowerCase(),
+    );
   });
   document.body.addEventListener('click', this.handleTermTouch.bind(this));
   document.body.addEventListener('keyup', this.handleTermTouch.bind(this));
@@ -161,8 +180,7 @@ Glossary.prototype.handleTermTouch = function(e) {
       this.show(e);
       this.selectedTerm = e.target;
       this.findTerm(e.target.getAttribute('data-term'));
-    }
-    else {
+    } else {
       this.selectedTerm = this.toggleBtn;
     }
   }
@@ -177,9 +195,12 @@ Glossary.prototype.findTerm = function(term) {
   forEach(this.body.querySelectorAll('.' + highlightClass), function(term) {
     term.classList.remove(highlightClass);
   });
-  forEach(this.body.querySelectorAll('span[data-term="' + term + '"]'), function(term) {
-    term.classList.add(highlightClass);
-  });
+  forEach(
+    this.body.querySelectorAll('span[data-term="' + term + '"]'),
+    function(term) {
+      term.classList.add(highlightClass);
+    },
+  );
   this.list.filter(function(item) {
     return item._values['data-glossary-term'].toLowerCase() === term;
   });
@@ -228,9 +249,9 @@ Glossary.prototype.handleKeyup = function(e) {
 
 // Close glossary when clicking outside of glossary
 Glossary.prototype.closeOpenGlossary = function(e) {
-  if ( e.target !== this.toggleBtn && this.isOpen) {
-    if (!(closest(e.target, this.selectors.glossaryID))) {
-        this.hide();
+  if (e.target !== this.toggleBtn && this.isOpen) {
+    if (!closest(e.target, this.selectors.glossaryID)) {
+      this.hide();
     }
   }
 };
@@ -241,7 +262,7 @@ Glossary.prototype.addEventListener = function(elm, event, callback) {
     this.listeners.push({
       elm: elm,
       event: event,
-      callback: callback
+      callback: callback,
     });
   }
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -241,18 +241,25 @@ Glossary.prototype.findTerm = function(term) {
 
   // show terms that match the search criteria and store the first term that was found
   let firstTerm = null;
+  let exactTerm = null;
   forEach(
     this.body.querySelectorAll('li[data-glossary-term-value*="' + lowerCaseTerm + '"]'),
     function (term) {
       term.style.cssText = 'display: list-item;'
       if(!firstTerm) firstTerm = term;
+      console.log('term: ', term);
+      if(lowerCaseTerm === term.toLowerCase()) exactTerm = term;
     }
   );
   
   collapseTerms(this.accordion, this.list);
   
   // expand the first term
-  if(firstTerm) {
+  if(exactTerm) {
+    var button = exactTerm.querySelector('button');
+    this.accordion.expand(button);
+  }
+  else if(firstTerm) {
     var button = firstTerm.querySelector('button');
     this.accordion.expand(button);
   }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -203,7 +203,7 @@ Glossary.prototype.handleTermTouch = function(e) {
   if (e.which === KEYCODE_ENTER || e.type === 'click') {
     if (selectorMatches(e.target, '[data-term]')) {
       this.show(e);
-      this.findTerm(e.target.getAttribute('data-term'));
+      this.findTerm(e.target.getAttribute('data-term'), true);
     }
 
     this.selectedTerm = e.target;
@@ -211,7 +211,7 @@ Glossary.prototype.handleTermTouch = function(e) {
 };
 
 /** Highlight a term */
-Glossary.prototype.findTerm = function(term) {
+Glossary.prototype.findTerm = function(term, fromTouch = false) {
   // skip find term if the search box is not on the DOM
   if(!this.search) return ;
 
@@ -239,31 +239,37 @@ Glossary.prototype.findTerm = function(term) {
     }
   );
 
-  // show terms that match the search criteria and store the first term that was found
-  let firstTerm = null;
-  let exactTerm = null;
-  forEach(
-    this.body.querySelectorAll('li[data-glossary-term-value*="' + lowerCaseTerm + '"]'),
-    function (term) {
-      term.style.cssText = 'display: list-item;'
-      if(!firstTerm) firstTerm = term;
-
-      const termStr = term.getAttribute('data-glossary-term-value')
-      console.log('term: ', termStr);
-      if(lowerCaseTerm === termStr.toLowerCase()) exactTerm = term;
-    }
-  );
-  
   collapseTerms(this.accordion, this.list);
+
+  // perform a search on the provided term
+  const exactMatch = this.body.querySelectorAll('li[data-glossary-term-value="' + lowerCaseTerm + '"]');
+  const matches = this.body.querySelectorAll('li[data-glossary-term-value*="' + lowerCaseTerm + '"]');
   
-  // expand the first term
-  if(exactTerm) {
-    var button = exactTerm.querySelector('button');
-    this.accordion.expand(button);
-  }
-  else if(firstTerm) {
-    var button = firstTerm.querySelector('button');
-    this.accordion.expand(button);
+  if(fromTouch) {
+    if(exactMatch.length > 0) {
+      // show the exact match term 
+      const term = exactMatch[0];
+      term.style.cssText = 'display: list-item;'
+
+      // expand the exact match term
+      var button = term.querySelector('button');
+      this.accordion.expand(button);      
+    }
+    else if(firstTerm) {
+      // show terms that match the search criteria and store the first term that was found
+      let firstTerm = null;
+      forEach(
+        matches,
+        function (term) {
+          term.style.cssText = 'display: list-item;'
+          if(!firstTerm) firstTerm = term;
+        }
+      );
+
+      // expand the first term, only if from term touch event and not for search input
+      var button = firstTerm.querySelector('button');
+      this.accordion.expand(button);
+    }
   }
 };
 
@@ -320,8 +326,6 @@ Glossary.prototype.handleInput = function() {
       }
     );
   }
-
-  collapseTerms(this.accordion, this.list);
 };
 
 /** Close glossary on escape keypress */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,12 +212,12 @@ Glossary.prototype.findTerm = function(term) {
 };
 
 Glossary.prototype.toggle = function() {
-  console.log('this: ', this);
   var method = this.isOpen ? this.hide : this.show;
   method.apply(this);
 };
 
 Glossary.prototype.show = function() {
+  console.log('this: ', this);
   this.body.setAttribute('aria-hidden', 'false');
   this.toggleBtn.setAttribute('aria-expanded', 'true');
   this.isOpen = true;
@@ -225,6 +225,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  console.log('this: ', this);
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -162,6 +162,7 @@ function Glossary(terms, selectors, classes) {
 }
 
 Glossary.prototype.populate = function() {
+  console.log('populate...');
   const termsAdded = [];
   this.terms.forEach(function(term) {
     if(!contains(termsAdded, term.term)) {
@@ -180,6 +181,7 @@ Glossary.prototype.populate = function() {
 
 /** Initialize list.js list of terms */
 Glossary.prototype.initList = function() {
+  console.log('initList...');
   var glossaryId = this.selectors.glossaryID.slice(1);
   var listClass = this.selectors.listClass.slice(1);
   var searchClass = this.selectors.searchClass.slice(1);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -260,7 +260,12 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  this.findTerm('');
+  forEach(
+    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    function (term) {
+      term.style = 'display: list-item;'
+    }
+  );
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -166,8 +166,9 @@ function Glossary(terms, selectors, classes) {
 /** Clears terms from the glossary list to ensure no duplication. */
 Glossary.prototype.clearTerms = function() {  
   console.log('clearterms...');
+  console.log(': ', document.getElementsByClassName('js-glossary-list'));
   forEach(
-    document.getElementsByClassName('js-glossary-search'),
+    document.getElementsByClassName('js-glossary-list'),
     function(list) {
       list.innerHTML = '';
     },

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -296,6 +296,9 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  //scroll Glossary panel to the top - handle older browsers where .scrollTo is not supported
+  this.body.scrollTop = 0;
+
   // remove the search criteria
   if (this.search){
     this.search.value = '';

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -209,7 +209,19 @@ Glossary.prototype.findTerm = function(term) {
   console.log('this.accordion: ', this.accordion);
   this.accordion.triggers.forEach((trigger) => {
     try {
-      this.accordion.collapse(trigger);
+      //this.accordion.collapse(trigger);
+      
+      // make our on safe version of the accordion collapse function
+      const control = trigger.getAttribute('aria-controls');
+      console.log('control: ', control);
+      const content = document.getElementById(control);
+      console.log('content: ', content);
+
+      if(content) {
+        trigger.setAttribute('aria-expanded', 'false');
+        content.setAttribute('aria-hidden', 'true');
+        this.accordion.setStyles(content);
+      }
     } catch (e) {
       console.log('e: ', e);
       console.log('trigger: ', trigger);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -247,8 +247,10 @@ Glossary.prototype.findTerm = function(term) {
     function (term) {
       term.style.cssText = 'display: list-item;'
       if(!firstTerm) firstTerm = term;
-      console.log('term: ', term);
-      if(lowerCaseTerm === term.toLowerCase()) exactTerm = term;
+
+      const termStr = term.getAttribute('data-glossary-term-value')
+      console.log('term: ', termStr);
+      if(lowerCaseTerm === termStr.toLowerCase()) exactTerm = termStr;
     }
   );
   

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -236,7 +236,7 @@ Glossary.prototype.findTerm = function(term) {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = 'display: none;'
+      term.style.cssText = 'display: none;'
     }
   );
 
@@ -245,7 +245,7 @@ Glossary.prototype.findTerm = function(term) {
   forEach(
     this.body.querySelectorAll('li[data-glossary-term-value*="' + lowerCaseTerm + '"]'),
     function (term) {
-      term.style = 'display: list-item;'
+      term.style.cssText = 'display: list-item;'
       if(!firstTerm) firstTerm = term;
     }
   );
@@ -317,7 +317,7 @@ Glossary.prototype.handleInput = function() {
     forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
-        term.style = 'display: list-item;'
+        term.style.cssText = 'display: list-item;'
       }
     );
   }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,6 +212,7 @@ Glossary.prototype.findTerm = function(term) {
 };
 
 Glossary.prototype.toggle = function() {
+  console.log('this: ', this);
   var method = this.isOpen ? this.hide : this.show;
   method.apply(this);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -144,6 +144,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this));
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -206,13 +206,10 @@ Glossary.prototype.findTerm = function(term) {
 
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
-  console.log('this.accordion: ', this.accordion);
-  this.accordion.collapseAll();
   this.accordion.expand(button);
 };
 
 Glossary.prototype.toggle = function() {
-  console.log('this: ', this);
   var method = this.isOpen ? this.hide : this.show;
   method.apply(this);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -56,6 +56,8 @@ var itemTemplate = function(values) {
     '">' +
     values.term +
     '</button>' +
+    '<button class=".js-glossary-test">Test</button>' +
+    '<button class=".js-glossary-test2">Test2</button>' +
     '<div class="' +
     values.definitionClass +
     '">' +
@@ -71,6 +73,8 @@ var defaultSelectors = {
   close: '.js-glossary-close',
   listClass: '.js-glossary-list',
   searchClass: '.js-glossary-search',
+  test: '.js-glossary-test',
+  test2: '.js-glossary-test2',
 };
 
 var defaultClasses = {
@@ -124,6 +128,8 @@ function Glossary(terms, selectors, classes) {
   this.body = document.querySelector(this.selectors.glossaryID);
   this.toggleBtn = document.querySelector(this.selectors.toggle);
   this.closeBtn = document.querySelector(this.selectors.close);
+  this.testBtn = document.querySelector(this.selectors.test);
+  this.testBtn2 = document.querySelector(this.selectors.test2);
   this.search = this.body.querySelector(this.selectors.searchClass);
   this.listElm = this.body.querySelector(this.selectors.listClass);
   this.selectedTerm = this.toggleBtn;
@@ -148,6 +154,8 @@ function Glossary(terms, selectors, classes) {
   this.listeners = [];
   this.addEventListener(this.toggleBtn, 'click', this.toggle.bind(this));
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
+  this.addEventListener(this.testBtn, 'click', this.populate.bind(this));
+  this.addEventListener(this.testBtn2, 'click', this.initList.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -93,7 +93,9 @@ function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
     console.log('term: ', term);
-    accordion.collapse(term.elm.firstChild);
+    const termElm = term.elm.firstChild;
+    const content = document.getElementById(termElm.getAttribute('aria-controls'));
+    if(content) accordion.collapse(term.elm.firstChild);
   })
 }
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -304,8 +304,8 @@ Glossary.prototype.handleInput = function() {
       function (term) {
         term.style = 'display: list-item;'
       }
-    );
-  } */
+    );*/
+  } 
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -96,7 +96,7 @@ function collapseTerms(accordion, list) {
   list.visibleItems.forEach((term) => {
     // Collapse the term if it is on the DOM
     const termElm = term.elm.firstChild;
-    const content = document.getElementById(termElm.getAttribute('aria-controls'));
+    const content = termElm ? document.getElementById(termElm.getAttribute('aria-controls')) : null;
     if(content) accordion.collapse(term.elm.firstChild);
   })
 }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -271,6 +271,7 @@ Glossary.prototype.show = function() {
 
 Glossary.prototype.hide = function() {
   //scroll to the top - handle older browsers where .scrollTo is not supported
+  alert("in hide function")
   try{
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -187,7 +187,7 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
-  this.accordion.collapseAll()
+  this.accordion.collapseAll();
 
   this.search.value = term;
   var highlightClass = this.classes.highlightedTerm;
@@ -233,11 +233,12 @@ Glossary.prototype.hide = function() {
 };
 
 /** Remove existing filters on input */
-Glossary.prototype.handleInput = function() {
-  this.accordion.collapseAll();
-  
+Glossary.prototype.handleInput = function() {  
+  console.log('this.list: ', this.list);
+  console.log('this.accordion: ', this.accordion);
   if (this.list.filtered) {
     this.list.filter();
+    this.accordion.collapseAll();
   }
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,6 +92,7 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
+    console.log('term: ', term);
     accordion.collapse(term.elm.firstChild);
   })
 }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -187,8 +187,6 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
-  this.accordion.collapseAll();
-
   this.search.value = term;
   var highlightClass = this.classes.highlightedTerm;
 
@@ -209,6 +207,7 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
 
+  collapseTerms();
   this.accordion.expand(button);
 };
 
@@ -234,17 +233,20 @@ Glossary.prototype.hide = function() {
 
 /** Remove existing filters on input */
 Glossary.prototype.handleInput = function() {  
-  console.log('this.list: ', this.list);
-  console.log('this.accordion: ', this.accordion);
   if (this.list.filtered) {
     this.list.filter();
   }
 
+  collapseTerms();
+};
+
+/** Collapse visible terms */
+function collapseTerms() {
   // collapse any visible terms
   this.list.visibleItems.forEach((term) => {
     this.accordion.collapse(term.elm.firstChild);
   })
-};
+}
 
 /** Close glossary on escape keypress */
 Glossary.prototype.handleKeyup = function(e) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -187,6 +187,8 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
+  this.accordion.collapseAll()
+  
   this.search.value = term;
   var highlightClass = this.classes.highlightedTerm;
 
@@ -207,7 +209,7 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
   console.log('this.accordion: ', this.accordion);
-  this.accordion.triggers.forEach((trigger) => {
+  /* this.accordion.triggers.forEach((trigger) => {
     try {
       //this.accordion.collapse(trigger);
       
@@ -226,7 +228,7 @@ Glossary.prototype.findTerm = function(term) {
       console.log('e: ', e);
       console.log('trigger: ', trigger);
     }
-  });
+  }); */
   //this.accordion.collapseAll();
   this.accordion.expand(button);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -276,6 +276,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  try{
   //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
@@ -298,6 +299,10 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+  }
+  catch(e){
+    alert(e)
+  }
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -73,6 +73,7 @@ var defaultSelectors = {
   searchClass: '.js-glossary-search',
   test: '.js-glossary-test',
   test2: '.js-glossary-test2',
+  test3: '.js-glossary-test3',
 };
 
 var defaultClasses = {
@@ -128,6 +129,7 @@ function Glossary(terms, selectors, classes) {
   this.closeBtn = document.querySelector(this.selectors.close);
   this.testBtn = document.querySelector(this.selectors.test);
   this.testBtn2 = document.querySelector(this.selectors.test2);
+  this.testBtn3 = document.querySelector(this.selectors.test3);
   this.search = this.body.querySelector(this.selectors.searchClass);
   this.listElm = this.body.querySelector(this.selectors.listClass);
   this.selectedTerm = this.toggleBtn;
@@ -155,6 +157,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.testBtn, 'click', this.populate.bind(this));
   this.addEventListener(this.testBtn2, 'click', this.initList.bind(this));
+  this.addEventListener(this.testBtn3, 'click', this.clearTerms.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
@@ -162,6 +165,7 @@ function Glossary(terms, selectors, classes) {
 
 /** Clears terms from the glossary list to ensure no duplication. */
 Glossary.prototype.clearTerms = function() {  
+  console.log('clearterms...');
   forEach(
     document.getElementsByClassName('js-glossary-search'),
     function(list) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,7 +92,6 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
-    console.log('term: ', term);
     const termElm = term.elm.firstChild;
     const content = document.getElementById(termElm.getAttribute('aria-controls'));
     if(content) accordion.collapse(term.elm.firstChild);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -188,7 +188,7 @@ Glossary.prototype.handleTermTouch = function(e) {
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
   this.accordion.collapseAll()
-  
+
   this.search.value = term;
   var highlightClass = this.classes.highlightedTerm;
 
@@ -208,28 +208,7 @@ Glossary.prototype.findTerm = function(term) {
 
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
-  console.log('this.accordion: ', this.accordion);
-  /* this.accordion.triggers.forEach((trigger) => {
-    try {
-      //this.accordion.collapse(trigger);
-      
-      // make our on safe version of the accordion collapse function
-      const control = trigger.getAttribute('aria-controls');
-      console.log('control: ', control);
-      const content = window.document.getElementById(control);
-      console.log('content: ', content);
 
-      if(content) {
-        trigger.setAttribute('aria-expanded', 'false');
-        content.setAttribute('aria-hidden', 'true');
-        this.accordion.setStyles(content);
-      }
-    } catch (e) {
-      console.log('e: ', e);
-      console.log('trigger: ', trigger);
-    }
-  }); */
-  //this.accordion.collapseAll();
   this.accordion.expand(button);
 };
 
@@ -239,7 +218,6 @@ Glossary.prototype.toggle = function() {
 };
 
 Glossary.prototype.show = function() {
-  console.log('this: ', this);
   this.body.setAttribute('aria-hidden', 'false');
   this.toggleBtn.setAttribute('aria-expanded', 'true');
   this.isOpen = true;
@@ -247,7 +225,6 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  console.log('this: ', this);
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
@@ -257,6 +234,8 @@ Glossary.prototype.hide = function() {
 
 /** Remove existing filters on input */
 Glossary.prototype.handleInput = function() {
+  this.accordion.collapseAll();
+  
   if (this.list.filtered) {
     this.list.filter();
   }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -209,7 +209,7 @@ Glossary.prototype.findTerm = function(term) {
     },
   );
   this.list.filter(function(item) {
-    return item._values['data-glossary-term'].toLowerCase() === term;
+    return item._values['data-glossary-term'].toLowerCase() === term.toLowerCase();
   });
 
   this.list.search();

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -101,6 +101,18 @@ function collapseTerms(accordion, list) {
   })
 }
 
+/** Shows or hides all terms */
+function showHideAllTerms(show) {
+  let display = show ? 'display: list-item;' : 'display: none;';
+
+  forEach(
+    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    function (term) {
+      term.style = display +
+    }
+  )
+}
+
 /**
  * Glossary widget
  * @constructor
@@ -219,12 +231,13 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  forEach(
+  showHideAllTerms(false);
+  /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: none;'
     }
-  );
+  ); */
 
   // show terms that match the search criteria and store the first term that was found
   let firstTerm = null;
@@ -260,12 +273,13 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  forEach(
+  showHideAllTerms();
+  /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: list-item;'
     }
-  );
+  ); */
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
@@ -284,13 +298,14 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    forEach(
+    showHideAllTerms(true);
+    /* forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
         term.style = 'display: list-item;'
       }
     );
-  }
+  } */
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -271,6 +271,7 @@ Glossary.prototype.show = function() {
 
 Glossary.prototype.hide = function() {
   //scroll to the top - handle older browsers where .scrollTo is not supported
+  try{
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
 
@@ -292,6 +293,10 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+  }
+  catch(e){
+    alert(e)
+  }
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,6 +212,7 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
+  try{
   // skip find term if the search box is not on the DOM
   if(!this.search) return ;
 
@@ -256,6 +257,10 @@ Glossary.prototype.findTerm = function(term) {
     var button = firstTerm.querySelector('button');
     this.accordion.expand(button);
   }
+}
+catch(e){
+  alert(e)
+}
 };
 
 Glossary.prototype.toggle = function() {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -238,8 +238,12 @@ Glossary.prototype.handleInput = function() {
   console.log('this.accordion: ', this.accordion);
   if (this.list.filtered) {
     this.list.filter();
-    this.accordion.collapseAll();
   }
+
+  // collapse any visible terms
+  this.list.visibleItems.forEach((term) => {
+    this.accordion.collapse(term.elm.firstChild);
+  })
 };
 
 /** Close glossary on escape keypress */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -36,6 +36,14 @@ function forEach(values, callback) {
   return [].forEach.call(values, callback);
 }
 
+function contains(values, value) {
+  for(let i = 0; i < values.length; i++) {
+    if(values[i] === value) return true;
+  }
+
+  return false;
+}
+
 var itemTemplate = function(values) {
   return (
     '<li class="' +
@@ -146,15 +154,19 @@ function Glossary(terms, selectors, classes) {
 }
 
 Glossary.prototype.populate = function() {
+  const termsAdded = [];
   this.terms.forEach(function(term) {
-    var opts = {
-      term: term.term,
-      definition: term.definition,
-      definitionClass: this.classes.definitionClass,
-      glossaryItemClass: this.classes.glossaryItemClass,
-      termClass: this.classes.termClass,
-    };
-    this.listElm.insertAdjacentHTML('beforeend', itemTemplate(opts));
+    if(!contains(termsAdded, term.term)) {
+      termsAdded.push(term.term);
+      var opts = {
+        term: term.term,
+        definition: term.definition,
+        definitionClass: this.classes.definitionClass,
+        glossaryItemClass: this.classes.glossaryItemClass,
+        termClass: this.classes.termClass,
+      };
+      this.listElm.insertAdjacentHTML('beforeend', itemTemplate(opts));
+    }
   }, this);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,6 +258,9 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  //scroll to the top
+  this.body.scrollTo(0, 0);
+
   // remove the search criteria
   this.search.value = '';
   forEach(

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -176,7 +176,7 @@ Glossary.prototype.linkTerms = function() {
     term.setAttribute('tabIndex', 0);
     term.setAttribute(
       'data-term',
-      (term.getAttribute('data-term') || '').toLowerCase(),
+      (term.getAttribute('data-term') || ''),
     );
   });
   document.body.addEventListener('click', this.handleTermTouch.bind(this));

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -296,10 +296,6 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top: handle older browsers where .scrollTo is not supported
-  const scrollingElement = document.scrollingElement || document.documentElement;
-  scrollingElement.scrollTop = 0;
-
   // remove the search criteria
   if (this.search){
     this.search.value = '';

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,7 +212,6 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
-  try{
   // skip find term if the search box is not on the DOM
   if(!this.search) return ;
 
@@ -257,10 +256,6 @@ Glossary.prototype.findTerm = function(term) {
     var button = firstTerm.querySelector('button');
     this.accordion.expand(button);
   }
-}
-catch(e){
-  alert(e)
-}
 };
 
 Glossary.prototype.toggle = function() {
@@ -276,7 +271,6 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  try{
   //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
@@ -299,10 +293,6 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-  }
-  catch(e){
-    alert(e)
-  }
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -276,7 +276,6 @@ Glossary.prototype.findTerm = function(term, fromTouch = false) {
       matches,
       function (term) {
         term.style.cssText = 'display: list-item;'
-        if(!firstTerm) firstTerm = term;
       }
     );
   }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -178,11 +178,10 @@ Glossary.prototype.handleTermTouch = function(e) {
   if (e.which === KEYCODE_ENTER || e.type === 'click') {
     if (selectorMatches(e.target, '[data-term]')) {
       this.show(e);
-      this.selectedTerm = e.target;
       this.findTerm(e.target.getAttribute('data-term'));
-    } else {
-      this.selectedTerm = this.toggleBtn;
     }
+
+    this.selectedTerm = e.target;
   }
 };
 
@@ -249,7 +248,11 @@ Glossary.prototype.handleKeyup = function(e) {
 
 // Close glossary when clicking outside of glossary
 Glossary.prototype.closeOpenGlossary = function(e) {
-  if (e.target !== this.toggleBtn && this.isOpen) {
+  if (
+    e.target !== this.toggleBtn &&
+    !e.target.getAttribute('data-term') &&
+    this.isOpen
+  ) {
     if (!closest(e.target, this.selectors.glossaryID)) {
       this.hide();
     }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -207,6 +207,7 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
   console.log('this.accordion: ', this.accordion);
+  this.accordion.collapseAll();
   this.accordion.expand(button);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,16 +258,16 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  // remove the search criteria
+  this.search.value = '';
+  this.findTerm('');
+  
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-
-  // remove the search criteria
-  this.search.value = '';
-  this.findTerm('');
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -102,15 +102,15 @@ function collapseTerms(accordion, list) {
 }
 
 /** Shows or hides all terms */
-function showHideAllTerms(show) {
-  let display = show ? 'display: list-item;' : 'display: none;';
+function showHideAllTerms(show, className) {
+  const cssValue = show ? 'display: list-item;' : 'display: none;';
 
   forEach(
-    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    this.body.querySelectorAll('li[class*="' + className + '"]'),
     function (term) {
-      term.style = display;
+      term.style = cssValue;
     }
-  )
+  );
 }
 
 /**
@@ -231,7 +231,7 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  showHideAllTerms(false);
+  showHideAllTerms(false, this.classes.glossaryItemClass);
   /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
@@ -273,7 +273,7 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  showHideAllTerms();
+  showHideAllTerms(true, this.classes.glossaryItemClass);
   /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
@@ -298,7 +298,7 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    showHideAllTerms(true);
+    showHideAllTerms(true, this.classes.glossaryItemClass);
     /* forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -217,7 +217,6 @@ Glossary.prototype.toggle = function() {
 Glossary.prototype.show = function() {
   this.body.setAttribute('aria-hidden', 'false');
   this.toggleBtn.setAttribute('aria-expanded', 'true');
-  this.search.focus();
   this.isOpen = true;
   restoreTabindex(this.body);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -214,7 +214,7 @@ Glossary.prototype.findTerm = function(term) {
       // make our on safe version of the accordion collapse function
       const control = trigger.getAttribute('aria-controls');
       console.log('control: ', control);
-      const content = document.getElementById(control);
+      const content = window.document.getElementById(control);
       console.log('content: ', content);
 
       if(content) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -121,6 +121,7 @@ function Glossary(terms, selectors, classes) {
   // Initialize accordions
   this.accordion = new Accordion(this.listElm, null, {
     contentPrefix: 'glossary',
+    collapseOthers: true,
   });
 
   // Bind listeners
@@ -207,7 +208,6 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
   console.log('this.accordion: ', this.accordion);
-  this.accordion.collapseAll();
   this.accordion.expand(button);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -270,8 +270,9 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top
-  this.body.scrollTo(0, 0);
+  //scroll to the top - handle older browsers where .scrollTo is not supported
+  const scrollingElement = document.scrollingElement || document.documentElement;
+  scrollingElement.scrollTop = 0;
 
   // remove the search criteria
   if (this.search){
@@ -280,7 +281,8 @@ Glossary.prototype.hide = function() {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = 'display: list-item;'
+      // handle older browsers where .style is readonly
+      term.style.cssText = 'display: list-item;'
     }
   );
   

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -101,18 +101,6 @@ function collapseTerms(accordion, list) {
   })
 }
 
-/** Shows or hides all terms */
-function showHideAllTerms(show, className) {
-  const cssValue = show ? 'display: list-item;' : 'display: none;';
-
-  forEach(
-    this.body.querySelectorAll('li[class*="' + className + '"]'),
-    function (term) {
-      term.style = cssValue;
-    }
-  );
-}
-
 /**
  * Glossary widget
  * @constructor
@@ -231,13 +219,12 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  showHideAllTerms(false, this.classes.glossaryItemClass);
-  /* forEach(
+  forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: none;'
     }
-  ); */
+  );
 
   // show terms that match the search criteria and store the first term that was found
   let firstTerm = null;
@@ -273,13 +260,12 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  showHideAllTerms(true, this.classes.glossaryItemClass);
-  /* forEach(
+  forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: list-item;'
     }
-  ); */
+  );
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
@@ -298,14 +284,13 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    showHideAllTerms(true, this.classes.glossaryItemClass);
-    /* forEach(
+    forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
         term.style = 'display: list-item;'
       }
-    );*/
-  } 
+    );
+  }
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -121,7 +121,6 @@ function Glossary(terms, selectors, classes) {
   // Initialize accordions
   this.accordion = new Accordion(this.listElm, null, {
     contentPrefix: 'glossary',
-    collapseOthers: true,
   });
 
   // Bind listeners
@@ -208,6 +207,15 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
   console.log('this.accordion: ', this.accordion);
+  this.accordion.triggers.forEach((trigger) => {
+    try {
+      this.accordion.collapse(trigger);
+    } catch (e) {
+      console.log('e: ', e);
+      console.log('trigger: ', trigger);
+    }
+  });
+  //this.accordion.collapseAll();
   this.accordion.expand(button);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -159,7 +159,6 @@ Glossary.prototype.clearTerms = function() {
 
 Glossary.prototype.populate = function() {
   this.terms.forEach(function(term) {
-    termsAdded.push(term.term);
     var opts = {
       term: term.term,
       definition: term.definition,

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -270,6 +270,15 @@ Glossary.prototype.findTerm = function(term, fromTouch = false) {
       var button = firstTerm.querySelector('button');
       this.accordion.expand(button);
     }
+  } else {
+    // from search input, go ahead and show all partial matches
+    forEach(
+      matches,
+      function (term) {
+        term.style.cssText = 'display: list-item;'
+        if(!firstTerm) firstTerm = term;
+      }
+    );
   }
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,6 +92,7 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
+    // Collapse the term if it is on the DOM
     const termElm = term.elm.firstChild;
     const content = document.getElementById(termElm.getAttribute('aria-controls'));
     if(content) accordion.collapse(term.elm.firstChild);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -143,8 +143,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
-  this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
-  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'click touchstart', this.closeOpenGlossary.bind(this));
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -143,7 +143,8 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
-  this.addEventListener(document, 'click touchstart', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this)); // for iPads 
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */
@@ -270,9 +271,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top - handle older browsers where .scrollTo is not supported
-  alert("in hide function")
-  try{
+  //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
 
@@ -294,10 +293,6 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-  }
-  catch(e){
-    alert(e)
-  }
 };
 
 /** Remove existing filters on input */
@@ -336,7 +331,6 @@ Glossary.prototype.closeOpenGlossary = function(e) {
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {
-    alert('in closeopenglossary!')
     if (!closest(e.target, this.selectors.glossaryID)) {
       this.hide();
     }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -51,13 +51,11 @@ var itemTemplate = function(values) {
     '" data-glossary-term-value="' +
     values.term.toLowerCase() + 
     '">' +
-    '<button class="data-glossary-term testing ' +
+    '<button class="data-glossary-term ' +
     values.termClass +
     '">' +
     values.term +
     '</button>' +
-    '<button class="js-glossary-test">Test</button>' +
-    '<button class="js-glossary-test2">Test2</button>' +
     '<div class="' +
     values.definitionClass +
     '">' +

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -88,6 +88,14 @@ function getTabIndex(elm) {
   return elm.querySelectorAll('a, button, input, [tabindex]');
 }
 
+/** Collapse visible terms */
+function collapseTerms(accordion, list) {
+  // collapse any visible terms
+  list.visibleItems.forEach((term) => {
+    accordion.collapse(term.elm.firstChild);
+  })
+}
+
 /**
  * Glossary widget
  * @constructor
@@ -207,7 +215,7 @@ Glossary.prototype.findTerm = function(term) {
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
 
-  collapseTerms();
+  collapseTerms(this.accordion, this.list);
   this.accordion.expand(button);
 };
 
@@ -237,16 +245,8 @@ Glossary.prototype.handleInput = function() {
     this.list.filter();
   }
 
-  collapseTerms();
+  collapseTerms(this.accordion, this.list);
 };
-
-/** Collapse visible terms */
-function collapseTerms() {
-  // collapse any visible terms
-  this.list.visibleItems.forEach((term) => {
-    this.accordion.collapse(term.elm.firstChild);
-  })
-}
 
 /** Close glossary on escape keypress */
 Glossary.prototype.handleKeyup = function(e) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -206,6 +206,7 @@ Glossary.prototype.findTerm = function(term) {
 
   this.list.search();
   var button = this.list.visibleItems[0].elm.querySelector('button');
+  console.log('this.accordion: ', this.accordion);
   this.accordion.expand(button);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -255,7 +255,7 @@ Glossary.prototype.findTerm = function(term, fromTouch = false) {
       var button = term.querySelector('button');
       this.accordion.expand(button);      
     }
-    else if(firstTerm) {
+    else {
       // show terms that match the search criteria and store the first term that was found
       let firstTerm = null;
       forEach(
@@ -265,10 +265,12 @@ Glossary.prototype.findTerm = function(term, fromTouch = false) {
           if(!firstTerm) firstTerm = term;
         }
       );
-
+      
       // expand the first term, only if from term touch event and not for search input
-      var button = firstTerm.querySelector('button');
-      this.accordion.expand(button);
+      if(firstTerm) {
+        var button = firstTerm.querySelector('button');
+        this.accordion.expand(button);
+      }
     }
   } else {
     // from search input, go ahead and show all partial matches

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -51,13 +51,13 @@ var itemTemplate = function(values) {
     '" data-glossary-term-value="' +
     values.term.toLowerCase() + 
     '">' +
-    '<button class="data-glossary-term ' +
+    '<button class="data-glossary-term testing ' +
     values.termClass +
     '">' +
     values.term +
     '</button>' +
-    '<button class=".js-glossary-test">Test</button>' +
-    '<button class=".js-glossary-test2">Test2</button>' +
+    '<button class="js-glossary-test">Test</button>' +
+    '<button class="js-glossary-test2">Test2</button>' +
     '<div class="' +
     values.definitionClass +
     '">' +

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -71,9 +71,6 @@ var defaultSelectors = {
   close: '.js-glossary-close',
   listClass: '.js-glossary-list',
   searchClass: '.js-glossary-search',
-  test: '.js-glossary-test',
-  test2: '.js-glossary-test2',
-  test3: '.js-glossary-test3',
 };
 
 var defaultClasses = {
@@ -127,9 +124,6 @@ function Glossary(terms, selectors, classes) {
   this.body = document.querySelector(this.selectors.glossaryID);
   this.toggleBtn = document.querySelector(this.selectors.toggle);
   this.closeBtn = document.querySelector(this.selectors.close);
-  this.testBtn = document.querySelector(this.selectors.test);
-  this.testBtn2 = document.querySelector(this.selectors.test2);
-  this.testBtn3 = document.querySelector(this.selectors.test3);
   this.search = this.body.querySelector(this.selectors.searchClass);
   this.listElm = this.body.querySelector(this.selectors.listClass);
   this.selectedTerm = this.toggleBtn;
@@ -155,9 +149,6 @@ function Glossary(terms, selectors, classes) {
   this.listeners = [];
   this.addEventListener(this.toggleBtn, 'click', this.toggle.bind(this));
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
-  this.addEventListener(this.testBtn, 'click', this.populate.bind(this));
-  this.addEventListener(this.testBtn2, 'click', this.initList.bind(this));
-  this.addEventListener(this.testBtn3, 'click', this.clearTerms.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
@@ -165,8 +156,6 @@ function Glossary(terms, selectors, classes) {
 
 /** Clears terms from the glossary list to ensure no duplication. */
 Glossary.prototype.clearTerms = function() {  
-  console.log('clearterms...');
-  console.log(': ', document.getElementsByClassName('js-glossary-list'));
   forEach(
     document.getElementsByClassName('js-glossary-list'),
     function(list) {
@@ -176,7 +165,6 @@ Glossary.prototype.clearTerms = function() {
 }
 
 Glossary.prototype.populate = function() {
-  console.log('populate...');
   const termsAdded = [];
   this.terms.forEach(function(term) {
     if(!contains(termsAdded, term.term)) {
@@ -195,7 +183,6 @@ Glossary.prototype.populate = function() {
 
 /** Initialize list.js list of terms */
 Glossary.prototype.initList = function() {
-  console.log('initList...');
   var glossaryId = this.selectors.glossaryID.slice(1);
   var listClass = this.selectors.listClass.slice(1);
   var searchClass = this.selectors.searchClass.slice(1);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -36,15 +36,6 @@ function forEach(values, callback) {
   return [].forEach.call(values, callback);
 }
 
-// check if the value exists within the values array
-function contains(values, value) {
-  for(let i = 0; i < values.length; i++) {
-    if(values[i] === value) return true;
-  }
-
-  return false;
-}
-
 var itemTemplate = function(values) {
   return (
     '<li class="' +
@@ -167,20 +158,16 @@ Glossary.prototype.clearTerms = function() {
 }
 
 Glossary.prototype.populate = function() {
-  const termsAdded = [];
   this.terms.forEach(function(term) {
-    // Add the term if it hasn't already been added
-    if(!contains(termsAdded, term.term)) {
-      termsAdded.push(term.term);
-      var opts = {
-        term: term.term,
-        definition: term.definition,
-        definitionClass: this.classes.definitionClass,
-        glossaryItemClass: this.classes.glossaryItemClass,
-        termClass: this.classes.termClass,
-      };
-      this.listElm.insertAdjacentHTML('beforeend', itemTemplate(opts));
-    }
+    termsAdded.push(term.term);
+    var opts = {
+      term: term.term,
+      definition: term.definition,
+      definitionClass: this.classes.definitionClass,
+      glossaryItemClass: this.classes.glossaryItemClass,
+      termClass: this.classes.termClass,
+    };
+    this.listElm.insertAdjacentHTML('beforeend', itemTemplate(opts));
   }, this);
 };
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -262,7 +262,9 @@ Glossary.prototype.hide = function() {
   this.body.scrollTo(0, 0);
 
   // remove the search criteria
-  this.search.value = '';
+  if (this.search){
+    this.search.value = '';
+  } 
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -36,6 +36,7 @@ function forEach(values, callback) {
   return [].forEach.call(values, callback);
 }
 
+// check if the value exists within the values array
 function contains(values, value) {
   for(let i = 0; i < values.length; i++) {
     if(values[i] === value) return true;
@@ -159,6 +160,7 @@ Glossary.prototype.clearTerms = function() {
   forEach(
     document.getElementsByClassName('js-glossary-list'),
     function(list) {
+      // remove all child elements from the parent list (i.e. <ul>)
       list.innerHTML = '';
     },
   );
@@ -167,6 +169,7 @@ Glossary.prototype.clearTerms = function() {
 Glossary.prototype.populate = function() {
   const termsAdded = [];
   this.terms.forEach(function(term) {
+    // Add the term if it hasn't already been added
     if(!contains(termsAdded, term.term)) {
       termsAdded.push(term.term);
       var opts = {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -235,6 +235,7 @@ Glossary.prototype.hide = function() {
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
+  collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,6 +258,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  this.search.value = '';
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -250,7 +250,7 @@ Glossary.prototype.findTerm = function(term) {
 
       const termStr = term.getAttribute('data-glossary-term-value')
       console.log('term: ', termStr);
-      if(lowerCaseTerm === termStr.toLowerCase()) exactTerm = termStr;
+      if(lowerCaseTerm === termStr.toLowerCase()) exactTerm = term;
     }
   );
   

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -198,6 +198,9 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
+  // skip find term if the search box is not on the DOM
+  if(!this.search) return ;
+
   this.search.value = term;
   var highlightClass = this.classes.highlightedTerm;
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,13 +258,16 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  this.search.value = '';
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+
+  // remove the search criteria
+  this.search.value = '';
+  this.findTerm('');
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -298,7 +298,7 @@ Glossary.prototype.handleKeyup = function(e) {
 // Close glossary when clicking outside of glossary
 Glossary.prototype.closeOpenGlossary = function(e) {
   if (
-    e.target !== this.toggleBtn &&
+    (e.target !== this.toggleBtn && e.target.parentElement !== this.toggleBtn) &&
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -108,7 +108,7 @@ function showHideAllTerms(show) {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = display +
+      term.style = display;
     }
   )
 }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -336,6 +336,7 @@ Glossary.prototype.closeOpenGlossary = function(e) {
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {
+    alert('in closeopenglossary!')
     if (!closest(e.target, this.selectors.glossaryID)) {
       this.hide();
     }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -136,6 +136,7 @@ function Glossary(terms, selectors, classes) {
   this.isOpen = false;
 
   // Update DOM
+  this.clearTerms();
   this.populate();
   this.initList();
   this.linkTerms();
@@ -157,6 +158,16 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
+}
+
+/** Clears terms from the glossary list to ensure no duplication. */
+Glossary.prototype.clearTerms = function() {  
+  forEach(
+    document.getElementsByClassName('js-glossary-search'),
+    function(list) {
+      list.innerHTML = '';
+    },
+  );
 }
 
 Glossary.prototype.populate = function() {


### PR DESCRIPTION
This pull request fixes a few things that our team ran into while using this component.

- Added a function for collapsing all terms.
  - Issue: 
    - Before: If you expanded some terms, closed the glossary component and then reopened the glossary all of those terms would still be expanded. 
    - After: Whenever the user closes and reopens the glossary, all the terms will be collapsed. Similarly, if the user clicks a different term only the selected term will be expanded. 
- Made the searches and term clicks case insensitive. Previously terms had to be all lower case. 
  - Issue: 
    - Before: The data-term value would only work if it was all lower case, which meant the term the user clicked on would always show up in the search box all lower case. 
    - After: The data-term value is case insensitive, allowing the text in the search box to match the casing of the term being clicked. 
- Prevent focus on search box when clicking on a term. 
  - Issue: On mobile devices, clicking a term would open the keyboard which would take up most of the screen. This was happening because focus was being assigned to the search box.  
- Prevent focus on the glossary button when the user clicks somewhere outside of the glossary component. 
  - Issue: Whenever the user clicked outside of the glossary, focus was given to the glossary toggle button. This focus change would cause the screen to jump to the glossary toggle button, instead of just closing the glossary. 